### PR TITLE
Move mediahaven credentials into a block

### DIFF
--- a/prefect_meemoo/credentials.py
+++ b/prefect_meemoo/credentials.py
@@ -1,5 +1,7 @@
 from prefect.blocks.core import Block
 from pydantic import Field, SecretStr
+from mediahaven import MediaHaven
+from mediahaven.oauth2 import ROPCGrant
 
 
 class MediahavenCredentials(Block):
@@ -31,3 +33,21 @@ class MediahavenCredentials(Block):
     client_id: str = Field(default="", description="Mediahaven API client ID.")
     username: str = Field(default="", description="Mediahaven API username.")
     url: str = Field(default="", description="Mediahaven API URL.")
+
+    def get_client(self) -> MediaHaven:
+        '''
+        Helper method to get a MediaHaven client.
+
+        Returns:
+            - An authenticated MediaHaven client
+
+        Raises:
+            - ValueError: if the authentication failed.
+            - RequestTokenError: is the token cannot be requested
+        '''
+
+        grant = ROPCGrant(self.url, self.client_id, self.client_secret.get_secret_value())
+        grant.request_token(self.username, self.password.get_secret_value())
+        # Create MediaHaven client
+        client = MediaHaven(self.url, grant)
+        return client


### PR DESCRIPTION
@lennertvandevelde created this draft PR that leads to a cleaner and 'more prefect' approach. I haven't tested this though. Some changes are probably still needed (such as the docs).

In order to use this block in the UI, once should do `prefect block register --module prefect_meemoo.credentials`