### PR TITLE
Add kwargs to get_client and fix elastic version

### DIFF
--- a/prefect_meemoo/elasticsearch/credentials.py
+++ b/prefect_meemoo/elasticsearch/credentials.py
@@ -35,7 +35,7 @@ class ElasticsearchCredentials(Block):
     except KeyError:
         _block_schema_capabilities = ["meemoo-prefect", "credentials", "v"+ version('prefect-meemoo')]
 
-    def get_client(self) -> Elasticsearch:
+    def get_client(self, **kwargs) -> Elasticsearch:
         """
         Helper method to get an Elasticsearch client.
 
@@ -48,5 +48,6 @@ class ElasticsearchCredentials(Block):
             self.url,
             basic_auth=(self.username, self.password.get_secret_value()),
             verify_certs=False,
+            **kwargs
         )
         return client

--- a/requirements-elasticsearch.txt
+++ b/requirements-elasticsearch.txt
@@ -1,2 +1,2 @@
-elasticsearch
+elasticsearch==8.17.2
 pydantic==1.10.8


### PR DESCRIPTION
This PR tries to fix the elasticsearch client version and allow passing arguments to the constructor. I'm not great with python, so I'm not sure if the **kwargs thing will work this way.